### PR TITLE
Update live trading script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,32 @@
-# Finance Analysis
+# 금융 분석
 
-This project analyzes financial data using Bollinger Bands and provides a FastAPI server for real-time tracking and simple backtesting.
+이 프로젝트는 볼린저 밴드를 이용해 금융 데이터를 분석하고 FastAPI 서버를 통해 실시간 조회와 간단한 백테스트 기능을 제공합니다.
 
-## Installation
+## 설치 방법
 
 ```bash
 pip install -r requirements.txt
 ```
 
-## Usage
+## 사용법
 
-Start the FastAPI server:
+FastAPI 서버를 실행합니다:
 
 ```bash
 uvicorn server:app --reload
 ```
 
-Then access:
+접속 후 다음 엔드포인트를 활용할 수 있습니다:
 
-- `/analyze/{ticker}` – Get latest Bollinger Band signals for a ticker
-- `/backtest/{ticker}` – Run a backtest on historical data
+- `/analyze/{ticker}` – 지정한 종목의 최신 볼린저 밴드 신호 확인
+- `/backtest/{ticker}` – 지정한 기간의 데이터를 사용해 백테스트 수행
+
+## 실시간 거래 시뮬레이션
+
+볼린저 밴드 신호를 이용한 실시간 거래 시뮬레이션을 실행하려면 다음 명령을 사용합니다:
+
+```bash
+python live_trading.py
+```
+
+스크립트는 `live_trading.log` 파일에 매수·매도 기록과 포트폴리오 가치를 남기며 콘솔에도 내용을 출력합니다.

--- a/live_trading.py
+++ b/live_trading.py
@@ -1,0 +1,60 @@
+import time
+import pandas as pd
+import yfinance as yf
+import logging
+from strategies.bollinger import apply_bollinger
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(message)s",
+    handlers=[
+        logging.FileHandler("live_trading.log"),
+        logging.StreamHandler(),
+    ],
+)
+
+
+def run_live_trading(ticker: str = "AAPL", interval: str = "1m", cash: float = 10000.0):
+    """볼린저 밴드 신호로 간단한 실시간 매매를 시뮬레이션합니다."""
+    data = pd.DataFrame()
+    position = 0.0
+    cash_balance = cash
+    start_cash = cash
+    last_processed = None
+    logging.info("%s 종목 실시간 거래 시작 (초기 자본: $%.2f)", ticker, cash)
+    while True:
+        # Fetch the latest intraday data
+        df = yf.download(ticker, period="1d", interval=interval, auto_adjust=False)
+        if df.empty:
+            logging.warning("데이터를 가져오지 못함")
+            time.sleep(60)
+            continue
+        if not data.empty:
+            df = df[df.index > data.index[-1]]
+        if df.empty:
+            time.sleep(60)
+            continue
+        data = pd.concat([data, df])
+        if len(data) > 1000:
+            data = data.iloc[-1000:]
+        signals = apply_bollinger(data)
+        new_signals = signals if last_processed is None else signals[signals.index > last_processed]
+        for ts, row in new_signals.iterrows():
+            price = row["Close"]
+            if row["Buy"] and cash_balance > 0:
+                position = cash_balance / price
+                cash_balance = 0
+                logging.info("%s 매수 %.4f주 (가격 %.2f)", ts, position, price)
+            elif row["Sell"] and position > 0:
+                cash_balance = position * price
+                position = 0
+                logging.info("%s 매도 (가격 %.2f)", ts, price)
+            value = cash_balance + position * price
+            profit = value - start_cash
+            logging.info("%s 포트폴리오 가치 %.2f (수익 %.2f)", ts, value, profit)
+            last_processed = ts
+        time.sleep(60)
+
+
+if __name__ == "__main__":
+    run_live_trading()


### PR DESCRIPTION
## Summary
- translate README to Korean
- refine live trading logs with profit reporting

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f955b8c10832da416f5c7b409896e